### PR TITLE
Update s3store args 121450671

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: syberiaStages
 Type: Package
 Title: Syberia Stages
-Version: 0.2.3.9000
+Version: 0.2.3.9001
 Description: Syberia provides an opinionated unified framework for
     fast iteration on classifier development and deployment. It is
     founded on convention over configuration and aims to solve the
@@ -21,6 +21,7 @@ Imports:
     syberiaStructure,
     statsUtils
 Suggests:
+    s3mpi (>= 0.2.20),
     mungebits,
     testthatsomemore
 License: MIT

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Version 0.2.3.9001
+
+ * Added support for num_retries to s3 adapter
+
 # Version 0.2.3
 
  * Fixed a bug with s3 adapter where non-environment class objects error upon store.

--- a/R/adapter.r
+++ b/R/adapter.r
@@ -252,7 +252,7 @@ construct_s3_adapter <- function() {
     # or wants to overwrite an already existing file by providing an option,
     # pass it along to the s3read function.
     args <- list(obj = object, name = opts$resource, safe = FALSE,
-      num_tries = opts$num_tries %||% 0)
+      num_retries = opts$num_retries %||% 0)
     # Set `safe = FALSE` by default for backwards compatibility.
     # Since running syberia files is a reproducible process there
     # shouldn't be a lot of damage done

--- a/R/adapter.r
+++ b/R/adapter.r
@@ -251,7 +251,8 @@ construct_s3_adapter <- function() {
     # If the user provided an s3 path, like "s3://somebucket/some/path/",
     # or wants to overwrite an already existing file by providing an option,
     # pass it along to the s3read function.
-    args <- list(obj = object, name = opts$resource, safe = FALSE)
+    args <- list(obj = object, name = opts$resource, safe = FALSE,
+      num_tries = opts$num_tries %||% 0)
     # Set `safe = FALSE` by default for backwards compatibility.
     # Since running syberia files is a reproducible process there
     # shouldn't be a lot of damage done


### PR DESCRIPTION
If we really want to protect against the silent failures that we added a check for in s3mpi we should consider letting opts pass in the num_retries.  The updated version of s3mpi has resulted in multiple, sporadic failures (that would previously have been silent) now that it has been released in the wild.

The change below should cover the case where num_retries is not specified, but, at the same time, older versions of s3mpi will result in an unused argument error.  Because of that I added s3mpi to the suggests with a version requirement.  Also upped the version and news.  Open to reverting any of these changes if they are objectionable.